### PR TITLE
Simplified and clarified example

### DIFF
--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -31,7 +31,7 @@
             <Border Background="#FF024D70" Grid.Column="0">
                 <Grid>
                     <Viewbox>
-                        <TextBlock Text="{Binding Score.ScoreA, StringFormat=D2}" FontFamily="Lucida Console" Margin="5" />
+                        <Label Content="{Binding Score.ScoreA}" ContentStringFormat="D2" FontFamily="Lucida Console"></Label>
                     </Viewbox>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Command="{Binding DecA}"  Height="70" Width="70" VerticalAlignment="Bottom" Opacity="0.5" Margin="20">
@@ -46,7 +46,7 @@
             <Border Background="#FF7E0E03" Grid.Column="1">
                 <Grid>
                     <Viewbox>
-                        <TextBlock Text="{Binding Path=Score.ScoreB, StringFormat=D2}" FontFamily="Lucida Console" Margin="5"/>
+                        <Label Content="{Binding Score.ScoreB}" ContentStringFormat="D2"  FontFamily="Lucida Console"></Label>
                     </Viewbox>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Command="{Binding DecB}"  Height="70" Width="70" VerticalAlignment="Bottom" Opacity="0.5" Margin="20">

--- a/src/MainWindow.xaml
+++ b/src/MainWindow.xaml
@@ -1,8 +1,7 @@
 ﻿<Controls:MetroWindow
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:local="clr-namespace:ViewModels;assembly=gasby.Wpf"
-        xmlns:model="clr-namespace:ViewModels;assembly=gasby.Wpf"
+        xmlns:local="clr-namespace:Views;assembly=gasby.Wpf"
         xmlns:fsx="clr-namespace:FsXaml;assembly=FsXaml.Wpf"
         xmlns:fsxaml="http://github.com/fsprojects/FsXaml"
         xmlns:Controls="clr-namespace:MahApps.Metro.Controls;assembly=MahApps.Metro"
@@ -32,7 +31,7 @@
             <Border Background="#FF024D70" Grid.Column="0">
                 <Grid>
                     <Viewbox>
-                        <Label Content="{Binding ScoreA}" FontFamily="Lucida Console"></Label>
+                        <TextBlock Text="{Binding Score.ScoreA, StringFormat=D2}" FontFamily="Lucida Console" Margin="5" />
                     </Viewbox>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Command="{Binding DecA}"  Height="70" Width="70" VerticalAlignment="Bottom" Opacity="0.5" Margin="20">
@@ -47,7 +46,7 @@
             <Border Background="#FF7E0E03" Grid.Column="1">
                 <Grid>
                     <Viewbox>
-                        <Label Content="{Binding ScoreB}" FontFamily="Lucida Console"></Label>
+                        <TextBlock Text="{Binding Path=Score.ScoreB, StringFormat=D2}" FontFamily="Lucida Console" Margin="5"/>
                     </Viewbox>
                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
                         <Button Command="{Binding DecB}"  Height="70" Width="70" VerticalAlignment="Bottom" Opacity="0.5" Margin="20">

--- a/src/MainWindow.xaml.fs
+++ b/src/MainWindow.xaml.fs
@@ -1,66 +1,8 @@
-﻿namespace ViewModels
+﻿namespace Views
 
-open System
-open System.Windows
-open FSharp.ViewModule
 open FsXaml
 
-type MainView = XAML<"MainWindow.xaml", true>
-
-type Score = {
-    ScoreA: int
-    ScoreB: int
-} with 
-    static member zero = {ScoreA = 0; ScoreB = 0}
-
-
-type ScoringEvent = IncA | DecA | IncB | DecB | New
-
-type Controller = Score -> ScoringEvent -> Score
-
-
-type MainViewModel(controller : Controller) as self = 
-    inherit EventViewModelBase<ScoringEvent>()
-
-    let mutable score = Score.zero
-
-    let scoreA = self.Factory.Backing(<@ self.ScoreA @>, "00")
-    let scoreB = self.Factory.Backing(<@ self.ScoreB @>, "00")
-
-    let updateView () =
-        self.ScoreA <- score.ScoreA.ToString("D2")
-        self.ScoreB <- score.ScoreB.ToString("D2")
-
-    let eventHandler ev =
-        score <- controller score ev
-
-    do
-        self.EventStream
-        |> Observable.subscribe (eventHandler >> updateView)
-        |> ignore
-
-    member self.IncA = self.Factory.EventValueCommand(IncA)
-    member self.DecA = self.Factory.EventValueCommand(DecA)
-    member self.IncB = self.Factory.EventValueCommand(IncB)
-    member self.DecB = self.Factory.EventValueCommand(DecB)
-    member self.NewGame = self.Factory.EventValueCommand(New)
-
-    member self.ScoreA with get() = scoreA.Value 
-                        and set value = scoreA.Value <- value
-    member self.ScoreB with get() = scoreB.Value 
-                        and set value = scoreB.Value <- value
-
-
-module Handling = 
-
-    let controller score ev =
-       match ev with
-        | IncA -> {score with ScoreA = score.ScoreA + 1}
-        | DecA -> {score with ScoreA = score.ScoreA - 1}
-        | IncB -> {score with ScoreB = score.ScoreB + 1}
-        | DecB -> {score with ScoreB = score.ScoreB - 1}
-        | New -> Score.zero 
-
+type MainView = XAML<"MainWindow.xaml">
 
 type CompositionRoot() =
-    member x.ViewModel with get() = MainViewModel(Handling.controller)
+    member __.ViewModel = ViewModel.MainViewModel(ScoreModel.Score.adjustScore)

--- a/src/Model.fs
+++ b/src/Model.fs
@@ -1,0 +1,16 @@
+﻿namespace ScoreModel
+
+[<AutoOpen>]
+module ScoreTypes =
+    type Score = { ScoreA: int ; ScoreB: int }    
+    type ScoringEvent = IncA | DecA | IncB | DecB | New
+
+module Score =
+    let zero = {ScoreA = 0; ScoreB = 0}
+    let adjustScore score event =
+       match event with
+        | IncA -> {score with ScoreA = score.ScoreA + 1}
+        | DecA -> {score with ScoreA = max (score.ScoreA - 1) 0}
+        | IncB -> {score with ScoreB = score.ScoreB + 1}
+        | DecB -> {score with ScoreB = max (score.ScoreB - 1) 0}
+        | New -> zero 

--- a/src/ViewModel.fs
+++ b/src/ViewModel.fs
@@ -1,0 +1,23 @@
+﻿namespace ViewModel
+
+open ScoreModel
+open FSharp.ViewModule
+
+type MainViewModel(controller : Score -> ScoringEvent -> Score) as self = 
+    inherit EventViewModelBase<ScoringEvent>()
+
+    let score = self.Factory.Backing(<@ self.Score @>, Score.zero)
+
+    let eventHandler ev = score.Value <- controller score.Value ev
+
+    do
+        self.EventStream
+        |> Observable.add eventHandler
+
+    member this.IncA = this.Factory.EventValueCommand(IncA)
+    member this.DecA = this.Factory.EventValueCommandChecked(DecA, (fun _ -> this.Score.ScoreA > 0), [ <@@ this.Score @@> ])
+    member this.IncB = this.Factory.EventValueCommand(IncB)
+    member this.DecB = this.Factory.EventValueCommandChecked(DecB, (fun _ -> this.Score.ScoreB > 0), [ <@@ this.Score @@> ])
+    member this.NewGame = this.Factory.EventValueCommand(New)
+
+    member __.Score = score.Value 

--- a/src/gasby.Wpf.fsproj
+++ b/src/gasby.Wpf.fsproj
@@ -9,7 +9,8 @@
     <OutputType>WinExe</OutputType>
     <RootNamespace>gasby.Wpf</RootNamespace>
     <AssemblyName>gasby.Wpf</AssemblyName>
-    <targetframeworkversion>v4.5</targetframeworkversion>
+    <RestorePackages>true</RestorePackages>
+    <Targetframeworkversion>v4.5</Targetframeworkversion>
     <TargetFSharpCoreVersion>4.3.0.0</TargetFSharpCoreVersion>
     <Name>gasby.Wpf</Name>
   </PropertyGroup>
@@ -35,6 +36,8 @@
     <DocumentationFile>bin\Release\gasby.Wpf.XML</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Model.fs" />
+    <Compile Include="ViewModel.fs" />
     <Resource Include="MainWindow.xaml" />
     <Compile Include="MainWindow.xaml.fs" />
     <Resource Include="App.xaml" />
@@ -45,19 +48,19 @@
   <ItemGroup>
     <Reference Include="Accessibility" />
     <Reference Include="FSharp.ViewModule.Core.Wpf">
-      <HintPath>..\packages\FSharp.ViewModule.Core.0.9.9.1\lib\net45\FSharp.ViewModule.Core.Wpf.dll</HintPath>
+      <HintPath>packages\FSharp.ViewModule.Core.0.9.9.1\lib\net45\FSharp.ViewModule.Core.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf">
-      <HintPath>..\packages\FsXaml.Wpf.0.9.9\lib\net45\FsXaml.Wpf.dll</HintPath>
+      <HintPath>packages\FsXaml.Wpf.0.9.9\lib\net45\FsXaml.Wpf.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FsXaml.Wpf.TypeProvider">
-      <HintPath>..\packages\FsXaml.Wpf.0.9.9\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
+      <HintPath>packages\FsXaml.Wpf.0.9.9\lib\net45\FsXaml.Wpf.TypeProvider.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="MahApps.Metro">
-      <HintPath>..\packages\MahApps.Metro.1.0.0.0\lib\net45\MahApps.Metro.dll</HintPath>
+      <HintPath>packages\MahApps.Metro.1.0.0.0\lib\net45\MahApps.Metro.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -89,7 +92,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Windows.Interactivity">
-      <HintPath>..\packages\MahApps.Metro.1.0.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
+      <HintPath>packages\MahApps.Metro.1.0.0.0\lib\net45\System.Windows.Interactivity.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xaml" />


### PR DESCRIPTION
This PR does a few things:
1. Moves model and VM into separate namespaces/files, which makes it clear which portions of the code are in separate "layers". That's often a problem in examples - the boundaries aren't clear.
2. Simplifies VM from original.  Instead of managing multiple properties and a separate mutable, the record is just treated as a single property.
3. Added small logic to prevent negative scores, and made that reflect in the View (Dec commands disable when score==0)

Just thought I'd "flush out" the example a bit, since it's a really good example ;)
